### PR TITLE
Fix worst strategy: Its winrate is 53.3%, not 40%

### DIFF
--- a/orchard/monte_carlo_simulation.py
+++ b/orchard/monte_carlo_simulation.py
@@ -26,7 +26,8 @@ def decrease_min(fruits):
     for i, v in enumerate(fruits):
         if v < mv and v > 0:
             mi,mv = i,v
-    fruits[mi] = mv-1
+    if mv < 11:
+        fruits[mi] = mv-1
 
 def decrease_random(fruits):
     mi = random.randint(0,3)
@@ -56,9 +57,9 @@ def simulate_orchard_random(count):
 
 print('Winning rates of 10 runs of the best strategy with 50 games: \n%s' %
       ([str(simulate_orchard_best(50)) + '%' for _ in range(10)]))
-    
-print('Winning rates of 10 runs of the best strategy with 1000 games: %s' %
-      ([str(simulate_orchard_best(1000)) + '%' for _ in range(10)])) 
+
+print('Winning rates of 10 runs of the best strategy with 1000 games: \n%s' %
+      ([str(simulate_orchard_best(1000)) + '%' for _ in range(10)]))
 
 print('Winning rates of 10 runs of the worst strategy with 50 games: \n%s' %
       ([str(simulate_orchard_worst(50)) + '%' for _ in range(10)]))


### PR DESCRIPTION
The bug in the old worst strategy was:
Assume there is only 1 fruit on 1 tree, and 0 on the 3 others.
You roll a basket and invoke the worst strategy.
First, the lone fruit is removed.
Second, you hang 10 new fruit on the first tree.

This makes the round nearly unwinnable, and was the reason for a dent in the win rate (to 40%) instead of 53.3%.

Now, the win rates of all 3 strategies match what I determined with my completely unrelated implementation before I found yours. :-)